### PR TITLE
Fix mic lag/distortion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _obj
 onair.exe
 onair
 onair_server
+build/onair.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
-main: build
+# This Makefile operates under the assumption that the Raspberry Pi has been
+# configured as a host named 'onair' in ssh config. It also assumes that
+# the ssh keys are properly setup.
 
+main: clean build
+
+# Pass in mal_debug as a tag to get malgo debugging information.
+.PHONY: build
 build:
 ifdef TAGS
 	go build -tags ${TAGS}
@@ -9,5 +15,11 @@ endif
 
 	GOOS="linux" GOARM="6" GOARCH="arm" go build -o onair_server ./server/server.go
 
-debug:
-	$(MAKE) build TAGS="mal_debug"
+	tar cf build/onair.tar.gz scripts/deploy.sh scripts/onair.service onair_server
+
+clean:
+	rm -rf onair.exe onair_server build/*
+
+deploy: clean build
+	scp build/onair.tar.gz onair:/home/pi
+	ssh -t onair "tar xf /home/pi/onair.tar.gz && sudo bash /home/pi/scripts/deploy.sh"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
+main: build
+
 build:
+ifdef TAGS
+	go build -tags ${TAGS}
+else
 	go build
+endif
 
-	export GOOS="linux"
-	export GOARM="6"
-	export GOARCH="arm"
+	GOOS="linux" GOARM="6" GOARCH="arm" go build -o onair_server ./server/server.go
 
-	go build -o onair_server ./server/server.go
+debug:
+	$(MAKE) build TAGS="mal_debug"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ To build inside PowerShell,
 go mod vendor
 go build
 
-$env:GO111MODULE="on"
 $env:GOOS="linux"
 $env:GOARCH="arm"
 $env:GOARM="6"
@@ -75,7 +74,7 @@ time="2019-01-21T20:26:37-08:00" level=info msg="Last known Discord muted/unmute
 time="2019-01-21T20:27:39-08:00" level=info msg="Muted on Discord."
 ```
 
-If you want to run OnAir on your windows host on boot then you might want to look into [nssm](https://nssm.cc/).
+If you want to run OnAir on your windows host on boot then you might want to look into [nssm](https://nssm.cc/). However, if you're using nssm you'll need to set the $HOME directory to your natural $HOME for the generated service.
 
 # Why
 

--- a/discord.go
+++ b/discord.go
@@ -10,11 +10,11 @@ import (
 )
 
 // Have discordgo handle any incoming events pushed to us by the Discord API.
-func discordEventReceiver() {
+func discordEventReceiver() (*discordgo.Session, error) {
 	dg, err := discordgo.New(config.Discord.Token)
 	if err != nil {
 		log.Error("Error creating Discord session: ", err)
-		return
+		return nil, err
 	}
 
 	dg.AddHandler(muting)
@@ -22,11 +22,11 @@ func discordEventReceiver() {
 	err = dg.Open()
 	if err != nil {
 		log.Error("Error opening Discord session: ", err)
-		return
+		return nil, err
 	}
 
 	log.Info("Discord event receiver active.")
-	defer dg.Close()
+	return dg, nil
 }
 
 // If Discord let's us know that we've been muted or unmuted

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/howdoicomputer/onair
 
 require (
 	github.com/bwmarrin/discordgo v0.19.0
-	github.com/gen2brain/malgo v0.0.0-20181117112449-af6b9a0d538d
+	github.com/gen2brain/malgo v0.0.0-20190202102829-36ec91e75a61
 	github.com/hashicorp/go-multierror v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/pkg/errors v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gen2brain/malgo v0.0.0-20181117112449-af6b9a0d538d h1:2UherObcCDNiGQfgoRL9KqDO+ubUTmGpeE0ta+6HC3g=
 github.com/gen2brain/malgo v0.0.0-20181117112449-af6b9a0d538d/go.mod h1:zHSUNZAXfCeNsZou0RtQ6Zk7gDYLIcKOrUWtAdksnEs=
+github.com/gen2brain/malgo v0.0.0-20190202102829-36ec91e75a61 h1:q+t/0E09j/Q6G7VoVVfKbPef3hPct+6UQugydWjhx0Q=
+github.com/gen2brain/malgo v0.0.0-20190202102829-36ec91e75a61/go.mod h1:zHSUNZAXfCeNsZou0RtQ6Zk7gDYLIcKOrUWtAdksnEs=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=

--- a/main.go
+++ b/main.go
@@ -127,7 +127,11 @@ func main() {
 	mikePoll(device)
 
 	// Start waiting for Discord mute/unmute events.
-	discordEventReceiver()
+	dg, err := discordEventReceiver()
+	if err != nil {
+		panic(os.Exit)
+	}
+	defer dg.Close()
 
 	// Continuously send our 'on air' status to the OnAir RPC server.
 	activityTimer(client)

--- a/main.go
+++ b/main.go
@@ -113,7 +113,18 @@ func main() {
 	}
 
 	// Start polling for microphone activity.
-	mikePoll()
+	ctx := initMikeContext()
+	defer func() {
+		_ = ctx.Uninit()
+		ctx.Free()
+	}()
+
+	device := initMikeDevice(ctx)
+	defer func() {
+		device.Uninit()
+	}()
+
+	mikePoll(device)
 
 	// Start waiting for Discord mute/unmute events.
 	discordEventReceiver()

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "Starting deployment."
+
+cd /home/pi
+
+rm /usr/local/bin/onair_server
+rm /etc/systemd/system/onair.service
+
+cp ./onair_server /usr/local/bin/onair_server
+chmod +x /usr/local/bin/onair_server
+
+cp ./scripts/onair.service /etc/systemd/system/onair.service
+chmod 664 /etc/systemd/system/onair.service
+
+systemctl daemon-reload
+systemctl restart onair.service
+
+rm -rf ./scripts ./onair_server ./onair.tar.gz
+
+systemctl is-active --quiet onair.service
+
+if [ $? -eq 0 ]; then
+    echo "Deployment successful."
+fi

--- a/scripts/onair.service
+++ b/scripts/onair.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=OnAir Server
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/onair_server
+Type=simple
+
+[Install]
+WantedBy=default.target

--- a/server/server.go
+++ b/server/server.go
@@ -32,8 +32,6 @@ func (o *OnAir) Speaking(speaking bool, ack *bool) error {
 	*ack = true
 
 	if speaking {
-		log.Info("Speaking detected.")
-
 		pin.DigitalWrite(1)
 	} else {
 		pin.DigitalWrite(0)
@@ -43,6 +41,10 @@ func (o *OnAir) Speaking(speaking bool, ack *bool) error {
 }
 
 func main() {
+	log.SetFormatter(&log.TextFormatter{
+		FullTimestamp: true,
+	})
+
 	addr, err := net.ResolveTCPAddr("tcp", "0.0.0.0:"+bindPort)
 	if err != nil {
 		log.Errorf("Error binding to port %s: %s", bindPort, err)

--- a/server/server.go
+++ b/server/server.go
@@ -22,8 +22,7 @@ var pin = gpio.NewDirectPinDriver(ada, "7")
 
 // OnAir An exported OnAir object.
 //
-// We don't actually care about the
-// object itself - only the exported
+// We don't actually care about the object itself - only the exported
 // Speaking method.
 type OnAir int
 


### PR DESCRIPTION
There is a problem where if OnAir has been running too long on my Windows machine... then other applications who need to use the mic are impacted. For example, if I try to turn on the in game mic in Dota 2, then the entire game lags and then maybe crashes altogether. If I try to join a Zoom conference, then people will tell me that my voice is coming through distorted and static-y.

This change defers the uninitialization of my microphone and any mini_al allocated contexts to the end of the program rather than within the mikePoll ticker.

More work may be added in if needed.